### PR TITLE
使用act_as_tenant 作为过滤器来过滤当前机构

### DIFF
--- a/app/controllers/scrinium_esm/admin/experiments_controller.rb
+++ b/app/controllers/scrinium_esm/admin/experiments_controller.rb
@@ -2,7 +2,8 @@ require_dependency "scrinium_esm/application_controller"
 
 module ScriniumEsm
   class Admin::ExperimentsController < ::Admin::ApplicationController
-  	defaults :route_prefix => 'admin'
+
+    defaults :route_prefix => 'admin'
     before_action :authenticate_user!
 
   end

--- a/app/controllers/scrinium_esm/admin/experiments_controller.rb
+++ b/app/controllers/scrinium_esm/admin/experiments_controller.rb
@@ -1,0 +1,11 @@
+require_dependency "scrinium_esm/application_controller"
+
+module ScriniumEsm
+  class Admin::ExperimentsController < ::Admin::ApplicationController
+  	defaults :route_prefix => 'admin'
+    before_action :authenticate_user!
+
+  end
+
+  # you can visit it in main_app. Url is  /admin/esm/admin/experiments
+end

--- a/app/controllers/scrinium_esm/application_controller.rb
+++ b/app/controllers/scrinium_esm/application_controller.rb
@@ -1,4 +1,20 @@
 module ScriniumEsm
   class ApplicationController < ::ApplicationController
+    set_current_tenant_through_filter
+    before_filter :set_current_organization
+
+    def set_current_organization
+      organization_id = params[:organization_id]
+      @organization = Organization.find_by(id: organization_id)
+      set_current_tenant(@organization)
+    end
+
+    helper_method :current_organization
+
+    # you can use current_organization in controllers and views
+    def current_organization
+      current_tenant
+    end
+
   end
 end

--- a/app/controllers/scrinium_esm/experiments_controller.rb
+++ b/app/controllers/scrinium_esm/experiments_controller.rb
@@ -6,8 +6,9 @@ module ScriniumEsm
     before_action :set_experiment, only: [ :show, :edit, :update, :destroy, :add_log ]
 
     def index
-      @organization = Organization.find(session[:current_organization_id])
-      @experiments = Experiment.where organization_id: session[:current_organization_id]
+      # @organization = Organization.find(session[:current_organization_id])
+      # @experiments = Experiment.where organization_id: session[:current_organization_id]
+      @experiments = Experiment.all  # this is select experiments with organizaton_id
     end
 
     def show

--- a/app/models/scrinium_esm/experiment.rb
+++ b/app/models/scrinium_esm/experiment.rb
@@ -1,6 +1,7 @@
 module ScriniumEsm
   class Experiment < ActiveRecord::Base
     extend Enumerize
+    acts_as_tenant(:organization)
 
     enumerize :experiment_type, in: [ :amip, :omip, :cmip ], predicate: true
     ModelType = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,4 +40,8 @@ ScriniumEsm::Engine.routes.draw do
   resources :atm_models
   # Data -----------------------------------------------------------------------
   resources :data
+
+  namespace :admin do
+    resources :experiments
+  end
 end


### PR DESCRIPTION
- 这个是一个例子，主要是在application_controllers 做了过滤，和model 中加了 `acts_as_tenant(:organization)`
这一句也可加入到其他model 中实现过滤。
- 在console 中比如查询子应用会报错，是由于得先设置了 租户的id
`ActsAsTenant.current_tenant = Organization.find(1) `
如此之后，查询的experiment 都会带 organization_id